### PR TITLE
Handling use case when rate symbol is an image

### DIFF
--- a/plugins/tobibeer/rate/styles.tid
+++ b/plugins/tobibeer/rate/styles.tid
@@ -33,6 +33,21 @@ opacity:1;
 color:orange;
 }
 
+.tc-rating img,
+.tc-rating svg
+{
+opacity: .125;
+}
+.tc-rating .tc-selected img,
+.tc-rating .tc-selected ~ button[class^="tc-rating-"] img,
+.tc-rating .tc-selected ~ button[class*="tc-rating-"] img,
+.tc-rating .tc-selected svg,
+.tc-rating .tc-selected ~ button[class^="tc-rating-"] svg,
+.tc-rating .tc-selected ~ button[class*="tc-rating-"] svg
+{
+opacity: 1;
+}
+
 .tc-rating-template {
 position:absolute;
 right:48px;


### PR DESCRIPTION
Adding a little bit of CSS so that images get properly handled when not selected. Was particularly breaking with read-only ratings.

My very simple test:
```
<<rate symbol:{{$:/core/images/home-button}}>>

<<rate symbol:{{$:/core/images/home-button}} readOnly:yes>>

<<rate readOnly:yes>>
```